### PR TITLE
Fix Hugo v0.162 deprecation errors and author map rendering

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -2,7 +2,7 @@
 # Last updated: 2025-08-15
 
 baseURL = "https://rajathpatel23.github.io/"
-languageCode = "en-us"
+locale = "en-us"
 title = "Rajat Patel"
 theme = "PaperMod"
 
@@ -86,6 +86,10 @@ enableRobotsTXT = true
   name = "email"
   url = "mailto:rpatel12@umbc.edu"
 
+[params.author]
+  name = "Rajat Patel"
+  email = "rpatel12@umbc.edu"
+
 [params.fuseOpts]
   isCaseSensitive = false
   shouldSort = true
@@ -126,7 +130,7 @@ enableRobotsTXT = true
     disabled = false
     simple = true
 
-  [privacy.twitter]
+  [privacy.x]
     disabled = false
     enableDNT = true
     simple = true

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -1,0 +1,11 @@
+{{- if or .Params.author site.Params.author }}
+{{- $author := (.Params.author | default site.Params.author) }}
+{{- $author_type := (printf "%T" $author) }}
+{{- if (or (eq $author_type "[]string") (eq $author_type "[]interface {}")) }}
+{{- (delimit $author ", " ) }}
+{{- else if eq $author_type "map[string]interface {}" }}
+{{- $author.name }}
+{{- else }}
+{{- $author }}
+{{- end }}
+{{- end -}}


### PR DESCRIPTION
- languageCode → locale
- privacy.twitter → privacy.x
- Add params.author map (name + email) to fix RSS site.Author error
- Override author.html partial to extract .name from map instead of rendering the raw map string